### PR TITLE
Update README for text transfer milestone and clean up Send/Receive UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
-<div align="center">
+﻿<div align="center">
   <img src="screenshots/sync360-icon.png" width="128" alt="Sync360 app icon" />
 
   # Sync360
 
-  **Send files across your own devices without the cloud getting involved.**
+  **Nearby device sharing without sending everything through the cloud first.**
 
-  Local-first device sharing, rebuilt from first principles with Kotlin Multiplatform.
+  Local-first Android device sharing, rebuilt from first principles with Kotlin Multiplatform.
 
   [![Kotlin](https://img.shields.io/badge/Kotlin-2.3.21-7F52FF?logo=kotlin&logoColor=white)](https://kotlinlang.org/)
   [![Compose Multiplatform](https://img.shields.io/badge/Compose%20Multiplatform-1.11.1-4285F4)](https://www.jetbrains.com/lp/compose-multiplatform/)
   [![Ktor](https://img.shields.io/badge/Ktor-3.5.1-087CFA)](https://ktor.io/)
   [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
-  <img src="screenshots/hero-demo.gif" alt="Sync360 Android-to-Android local request demo" width="1080" />
-  <sub>Current milestone: Android devices can discover each other locally and exchange a simple Ktor request/response.</sub>
+  <img src="screenshots/hero-demo.gif" alt="Sync360 Android text transfer demo" width="1080" />
+  <sub>Current milestone: Android devices can discover each other locally, send a text offer, accept or decline it, transfer text, and copy the received text.</sub>
 </div>
 
 ---
 
 ## The idea
 
-Your devices are already next to each other. They are often on the same Wi-Fi. Sending a large file should not always mean uploading it to a chat app or cloud drive first.
+Your devices are already next to each other. They are often on the same Wi-Fi. Sending something between them should not always mean opening a chat app, uploading it to a cloud drive, or sending it to yourself first.
 
 Sync360 is an early-stage local network sharing app. The long-term goal is simple:
 
@@ -28,11 +28,11 @@ Sync360 is an early-stage local network sharing app. The long-term goal is simpl
 same network -> discover nearby devices -> ask receiver -> send directly
 ```
 
-The project is being rebuilt manually and in public after an older AI-generated implementation became too large to confidently own. This version is intentionally smaller, Android-first, and focused on understanding every networking step before adding more product surface.
+The project is being rebuilt manually and in public after an older AI-generated implementation became too large to confidently own. This version is intentionally smaller, Android-first, and focused on understanding each networking step before adding more product surface.
 
 ## What Sync360 is
 
-Sync360 is a Kotlin Multiplatform / Compose Multiplatform app for local peer-to-peer file and data sharing.
+Sync360 is a Kotlin Multiplatform / Compose Multiplatform app for local nearby-device sharing.
 
 It is being built around these principles:
 
@@ -44,7 +44,7 @@ It is being built around these principles:
 
 ## Current status
 
-Sync360 is not a finished file transfer app yet. It is in an early rebuild phase.
+Sync360 is not a finished file transfer app yet. It is in an early Android-first rebuild phase.
 
 ### Working now
 
@@ -56,53 +56,47 @@ Sync360 is not a finished file transfer app yet. It is in an early rebuild phase
 - Resolved nearby devices with `hostAddresses` and dynamic `port`.
 - Embedded Ktor server inside the app.
 - OS-assigned HTTP server port advertised through NSD.
-- Ktor client calling a discovered device.
-- First local route: `GET /sync360/ping`.
-- Experimental receiver-side Accept/Decline proof for incoming ping requests.
+- Ktor client/server request-response over the local network.
+- Text offer route: `POST /sync360/text/offer`.
+- Text transfer route: `POST /sync360/text/transfer`.
+- Receiver-side Accept/Decline flow for incoming text offers.
+- Text is transferred only after receiver approval.
+- Receive screen can show received text and copy it.
+- Send and Receive screens use ViewModel-owned screen state.
 
-### Experimental
+### Not implemented yet
 
-- Send screen request status UI.
-- Receiver request state flow and navigation behavior.
-- Naming and boundaries around network controllers.
-- The current ping route is being used to learn request/response coordination; it is not the final send-offer protocol.
-
-### Planned
-
-- Real send-offer request and response DTOs.
-- File picker and selected item list.
-- Direct text snippet sending.
-- File byte transfer.
-- Transfer progress and result UI.
-- Android storage/save handling.
-- Desktop support for the rebuilt flow.
-- Security/session validation after the simple flow works.
+- File picker.
+- File transfer.
+- Transfer progress.
+- Android save-to-downloads/storage flow.
+- Security/encryption/session validation.
+- Desktop support for the rebuilt networking flow.
+- iOS implementation.
+- Production-ready error model.
 
 ## Demo and screenshots
 
-<!-- TODO: Add hero demo GIF here: screenshots/hero-demo.gif -->
-<!-- TODO: Add Android screenshot here: screenshots/android-send.png -->
-<!-- TODO: Add receiver approval screenshot here: screenshots/android-receive-request.png -->
-<!-- TODO: Add architecture preview here: screenshots/architecture-preview.png -->
-<!-- TODO: Add desktop screenshot later: screenshots/desktop-home.png -->
+The main demo GIF above shows the current Android text-transfer milestone.
 
 Place visual assets in [`screenshots/`](screenshots/README.md). The folder includes recommended filenames and sizes.
 
-## How the current prototype works
+## How the current Android flow works
 
 ```text
 Device A starts a local Ktor server
 Device A advertises itself with Android NSD
 Device B discovers Device A
 Device B reads Device A hostAddresses + port
-Device B calls http://host:port/sync360/ping
-Device A surfaces the request on Receive
-User accepts or declines
-Device A responds
-Device B receives Accepted or Declined
+Sender writes text
+Sender sends a text offer to the receiver
+Receiver accepts or declines
+If accepted, sender transfers the text
+Receiver shows the received text
+Receiver can copy the text
 ```
 
-This is the first control-plane milestone. It proves that local discovery can lead to an actual HTTP request and a structured response between two Android devices.
+This is the first real send flow. It proves that local discovery can lead to receiver approval and an actual payload transfer between two Android devices on the same network.
 
 ## Architecture
 
@@ -129,8 +123,8 @@ High-level module shape:
 
 - `androidApp/` - Android app entry point and manifest.
 - `desktopApp/` - JVM desktop app shell; present, but not active in the rebuilt flow yet.
-- `shared/commonMain/` - shared UI, ViewModels, domain models, Koin module, Ktor client/server prototype.
-- `shared/androidMain/` - Android NSD discovery and Android local identity implementation.
+- `shared/commonMain/` - shared UI, ViewModels, domain models, Koin module, Ktor client/server, request controllers, and DTOs.
+- `shared/androidMain/` - Android NSD discovery, local identity, local device info, and clipboard implementation.
 
 More detail: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
 
@@ -159,18 +153,16 @@ More detail: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
 - Android SDK Build Tools 36.0.0 or newer
 - Gradle is provided by the wrapper (`9.4.1`)
 - At least one Android device or emulator for app launch
-- Two physical Android devices on the same local network for real discovery testing
+- Two physical Android devices on the same local network for real discovery and transfer testing
 
 The project currently uses Android Gradle Plugin 9.2.1. Use a recent Android Studio version that supports AGP 9.2.x.
 
 ### Clone
 
 ```bash
-git clone <your-repo-url>
+git clone https://github.com/CodePandaaAI/Sync360.git
 cd Sync360
 ```
-
-Replace `<your-repo-url>` after the repository is public.
 
 ### Open in IDE
 
@@ -202,22 +194,23 @@ Desktop discovery and transfer behavior should be treated as future work unless 
 
 ## Roadmap
 
-### MVP direction
+### Current Android milestone
 
 - Android local discovery.
 - Dynamic local HTTP server port advertisement.
-- Simple request/response between two Android devices.
-- Real send offer with receiver Accept/Decline.
-- Direct text send.
-- One-file transfer.
+- Text offer with receiver Accept/Decline.
+- Direct text transfer after approval.
+- Received text display and copy action.
 
 ### Near-term
 
 - File selection UI.
-- Selected item list.
+- Selected file model.
+- File offer request/response.
+- File byte transfer.
 - Progress states.
+- Android save-to-downloads/storage handling.
 - Better error states.
-- Receiver result UI.
 - Cleaner lifecycle around server/discovery start and stop.
 - Better host address selection, including IPv4 preference and IPv6 formatting.
 
@@ -276,4 +269,4 @@ Created by **Romit Sharma**.
 - GitHub: https://github.com/CodePandaaAI
 - LinkedIn: https://www.linkedin.com/in/romit-sharma-18b521329/
 
-If this project sounds interesting, star it, follow the rebuild, or open a discussion when the repository goes public.
+If this project sounds interesting, star it, follow the rebuild, or open a discussion.

--- a/screenshots/README.md
+++ b/screenshots/README.md
@@ -1,13 +1,13 @@
-# Screenshots and Demo Assets
+﻿# Screenshots and Demo Assets
 
 Place public README/demo assets in this folder.
 
-The README currently references these placeholders:
+The README currently references these assets:
 
 | File | Purpose | Suggested size |
 | ---- | ------- | -------------- |
 | `sync360-icon.png` | App icon near README title | 512x512 PNG, transparent background if possible |
-| `hero-demo.gif` | Main README demo showing two devices discovering/requesting | 1200x675 or 1280x720 |
+| `hero-demo.gif` | Main README demo showing Android discovery, text offer, accept/decline, text transfer, and copy | 1200x675 or 1280x720 |
 | `android-send.png` | Android Send screen | 1080x2400 or cropped portrait |
 | `android-receive-request.png` | Receiver approval screen | 1080x2400 or cropped portrait |
 | `device-discovery.png` | Nearby device list close-up | 1080x1200 or readable crop |
@@ -18,7 +18,7 @@ The README currently references these placeholders:
 ## Recommended GitHub style
 
 - Keep images readable in both light and dark GitHub themes.
-- Prefer short GIFs under 10-15 seconds.
+- Prefer short GIFs under 10-15 seconds when possible.
 - Crop phone screenshots to the important screen area.
 - Avoid exposing private IPs, personal device names, or notification content.
 - Use real app screenshots when possible, not mockups.

--- a/shared/src/commonMain/kotlin/com/liftley/sync360/core/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/liftley/sync360/core/di/Koin.kt
@@ -3,8 +3,8 @@ package com.liftley.sync360.core.di
 import com.liftley.sync360.data.NetworkServicesController
 import com.liftley.sync360.data.network.http.client.Sync360HttpClient
 import com.liftley.sync360.data.network.http.server.Sync360HttpServer
-import com.liftley.sync360.data.remote.IncomingServerRequestsController
-import com.liftley.sync360.data.remote.OutgoingRequestsController
+import com.liftley.sync360.data.IncomingServerRequestsController
+import com.liftley.sync360.data.OutgoingRequestsController
 import com.liftley.sync360.presentation.navigation.NavigationViewModel
 import com.liftley.sync360.presentation.receive.ReceiveScreenViewModel
 import com.liftley.sync360.presentation.send.SendScreenViewModel

--- a/shared/src/commonMain/kotlin/com/liftley/sync360/data/IncomingServerRequestsController.kt
+++ b/shared/src/commonMain/kotlin/com/liftley/sync360/data/IncomingServerRequestsController.kt
@@ -1,4 +1,4 @@
-package com.liftley.sync360.data.remote
+package com.liftley.sync360.data
 
 import com.liftley.sync360.domain.model.ClientServerState
 import com.liftley.sync360.domain.model.UserDecision

--- a/shared/src/commonMain/kotlin/com/liftley/sync360/data/OutgoingRequestsController.kt
+++ b/shared/src/commonMain/kotlin/com/liftley/sync360/data/OutgoingRequestsController.kt
@@ -1,4 +1,4 @@
-package com.liftley.sync360.data.remote
+package com.liftley.sync360.data
 
 import com.liftley.sync360.data.network.http.client.Sync360HttpClient
 import com.liftley.sync360.data.network.http.dto.text.TextOfferRequest

--- a/shared/src/commonMain/kotlin/com/liftley/sync360/data/network/http/client/Sync360HttpClient.kt
+++ b/shared/src/commonMain/kotlin/com/liftley/sync360/data/network/http/client/Sync360HttpClient.kt
@@ -4,7 +4,6 @@ import com.liftley.sync360.data.network.http.dto.text.TextOfferRequest
 import com.liftley.sync360.data.network.http.dto.text.TextOfferResponse
 import com.liftley.sync360.data.network.http.dto.text.TextTransferRequest
 import com.liftley.sync360.data.network.http.dto.text.TextTransferResponse
-import com.liftley.sync360.data.remote.server.serverTextResponse.OfferException
 import com.liftley.sync360.domain.model.NearbyDevice
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -53,13 +52,13 @@ class Sync360HttpClient {
                 }
 
                 TextOfferResponse.Declined -> {
-                    Result.failure(OfferException("User Declined Request"))
+                    Result.failure(TextOfferException("User Declined Request"))
                 }
             }
         } catch (e: Exception) {
             when (e) {
                 is ConnectTimeoutException, is SocketTimeoutException, is HttpRequestTimeoutException -> {
-                    Result.failure(OfferException(e.message ?: "Device did not respond in time"))
+                    Result.failure(TextOfferException(e.message ?: "Device did not respond in time"))
                 }
 
                 else -> Result.failure(e)

--- a/shared/src/commonMain/kotlin/com/liftley/sync360/data/network/http/client/Sync360HttpClient.kt
+++ b/shared/src/commonMain/kotlin/com/liftley/sync360/data/network/http/client/Sync360HttpClient.kt
@@ -11,8 +11,9 @@ import io.ktor.client.call.body
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.network.sockets.ConnectTimeoutException
 import io.ktor.client.network.sockets.SocketTimeoutException
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.plugins.timeout
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
@@ -23,6 +24,11 @@ class Sync360HttpClient {
     private val httpClient: HttpClient = HttpClient(CIO) {
         install(ContentNegotiation) {
             json()
+        }
+        install(HttpTimeout) {
+            requestTimeoutMillis = 60_000
+            connectTimeoutMillis = 5_000
+            socketTimeoutMillis = 60_000
         }
     }
 
@@ -39,12 +45,6 @@ class Sync360HttpClient {
             val textOfferResponse = httpClient.post(url) {
                 contentType(ContentType.Application.Json)
                 setBody(textOfferRequest)
-
-                timeout {
-                    requestTimeoutMillis = 60_000 // 60 seconds
-                    connectTimeoutMillis = 5_000   // 5 seconds to physically connect
-                    socketTimeoutMillis = 60_000  // 60 seconds socket read inactivity
-                }
             }.body<TextOfferResponse>()
 
             when (textOfferResponse) {
@@ -57,11 +57,12 @@ class Sync360HttpClient {
                 }
             }
         } catch (e: Exception) {
-            if (e is ConnectTimeoutException || e is SocketTimeoutException) {
-                // Treat the lack of response as an automatic business decline
-                Result.failure(OfferException(e.message ?: ""))
-            } else {
-                Result.failure(e)
+            when (e) {
+                is ConnectTimeoutException, is SocketTimeoutException, is HttpRequestTimeoutException -> {
+                    Result.failure(OfferException(e.message ?: "Device did not respond in time"))
+                }
+
+                else -> Result.failure(e)
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/liftley/sync360/data/network/http/client/TextOfferException.kt
+++ b/shared/src/commonMain/kotlin/com/liftley/sync360/data/network/http/client/TextOfferException.kt
@@ -1,0 +1,3 @@
+package com.liftley.sync360.data.network.http.client
+
+class TextOfferException(response: String) : Exception("Offer status: $response")

--- a/shared/src/commonMain/kotlin/com/liftley/sync360/data/network/http/server/Sync360HttpServer.kt
+++ b/shared/src/commonMain/kotlin/com/liftley/sync360/data/network/http/server/Sync360HttpServer.kt
@@ -4,7 +4,7 @@ import com.liftley.sync360.data.network.http.dto.text.TextOfferRequest
 import com.liftley.sync360.data.network.http.dto.text.TextOfferResponse
 import com.liftley.sync360.data.network.http.dto.text.TextTransferRequest
 import com.liftley.sync360.data.network.http.dto.text.TextTransferResponse
-import com.liftley.sync360.data.remote.IncomingServerRequestsController
+import com.liftley.sync360.data.IncomingServerRequestsController
 import com.liftley.sync360.domain.model.ClientServerState
 import com.liftley.sync360.domain.model.UserDecision
 import io.ktor.serialization.kotlinx.json.json

--- a/shared/src/commonMain/kotlin/com/liftley/sync360/data/network/http/server/Sync360HttpServer.kt
+++ b/shared/src/commonMain/kotlin/com/liftley/sync360/data/network/http/server/Sync360HttpServer.kt
@@ -37,6 +37,12 @@ class Sync360HttpServer(
 
             routing {
                 post("/sync360/text/offer") {
+                    val currentState = incomingServerRequestsController.clientServerState.value
+
+                    if (currentState != ClientServerState.Idle) {
+                        call.respond(TextOfferResponse.Declined)
+                        return@post
+                    }
                     val textOfferRequest = call.receive<TextOfferRequest>()
 
                     incomingServerRequestsController.changeServerState(
@@ -52,11 +58,19 @@ class Sync360HttpServer(
                         incomingServerRequestsController.waitForUserDecision()
                     }
 
-                    if (userDecision == UserDecision.ACCEPTED) {
-                        call.respond(TextOfferResponse.Accepted)
-                    } else {
-                        incomingServerRequestsController.changeServerState(ClientServerState.Idle)
-                        call.respond(TextOfferResponse.Declined)
+                    when (userDecision) {
+                        UserDecision.ACCEPTED -> {
+                            call.respond(TextOfferResponse.Accepted)
+                        }
+                        UserDecision.DECLINED -> {
+                            incomingServerRequestsController.changeServerState(ClientServerState.Idle)
+                            call.respond(TextOfferResponse.Declined)
+                        }
+
+                        else -> {
+                            incomingServerRequestsController.changeServerState(ClientServerState.Idle)
+                            call.respond(TextOfferResponse.Declined)
+                        }
                     }
                 }
 

--- a/shared/src/commonMain/kotlin/com/liftley/sync360/data/remote/server/serverTextResponse/OfferException.kt
+++ b/shared/src/commonMain/kotlin/com/liftley/sync360/data/remote/server/serverTextResponse/OfferException.kt
@@ -1,3 +1,0 @@
-package com.liftley.sync360.data.remote.server.serverTextResponse
-
-class OfferException(response: String) : Exception("Offer status: $response")

--- a/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/receive/ReceiveScreen.kt
+++ b/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/receive/ReceiveScreen.kt
@@ -2,30 +2,23 @@ package com.liftley.sync360.presentation.receive
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Button
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.liftley.sync360.core.designsystem.icons.Emoji_Nature
 import com.liftley.sync360.domain.model.UserDecision
+import com.liftley.sync360.presentation.receive.components.IdleReceiveStateUi
+import com.liftley.sync360.presentation.receive.components.ReceivedTextStateUi
+import com.liftley.sync360.presentation.receive.components.TextOfferStateUi
 import com.liftley.sync360.presentation.receive.model.ReceiveScreenState
-import com.liftley.sync360.presentation.app.components.Sync360Surface
 import org.koin.compose.koinInject
 
 @Composable
@@ -52,11 +45,11 @@ fun ReceiveScreen() {
             ) {
                 when (val state = receiveScreenState) {
                     ReceiveScreenState.Idle -> {
-                        IdleReceiveState()
+                        IdleReceiveStateUi()
                     }
 
                     is ReceiveScreenState.IncomingTextOffer -> {
-                        TextOfferState(
+                        TextOfferStateUi(
                             state = state,
                             onAccept = { receiveScreenViewModel.makeDecision(UserDecision.ACCEPTED) },
                             onDecline = { receiveScreenViewModel.makeDecision(UserDecision.DECLINED) }
@@ -64,7 +57,7 @@ fun ReceiveScreen() {
                     }
 
                     is ReceiveScreenState.ReceivedText -> {
-                        ReceivedTextState(
+                        ReceivedTextStateUi(
                             text = state.text,
                             onCopyText = {
                                 receiveScreenViewModel.copyReceivedText(state.text)
@@ -75,160 +68,6 @@ fun ReceiveScreen() {
                             }
                         )
                     }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun IdleReceiveState() {
-    Sync360Surface {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(24.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Icon(
-                imageVector = Emoji_Nature,
-                contentDescription = null,
-                modifier = Modifier.size(48.dp)
-            )
-            Text(
-                "Nothing to receive right now",
-                style = MaterialTheme.typography.titleLarge
-            )
-            Text(
-                "Keep Sync360 open on nearby devices",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
-    }
-}
-
-@Composable
-private fun TextOfferState(
-    state: ReceiveScreenState.IncomingTextOffer,
-    onAccept: () -> Unit,
-    onDecline: () -> Unit
-) {
-    Sync360Surface {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            Text(
-                "Incoming text",
-                style = MaterialTheme.typography.titleLarge
-            )
-
-            Text(
-                "${state.senderName} wants to send text",
-                style = MaterialTheme.typography.titleMedium
-            )
-
-            Text(
-                "${state.characterCount} characters",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-
-            Sync360Surface(containerColor = MaterialTheme.colorScheme.surfaceContainer) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    Text(
-                        "Preview",
-                        style = MaterialTheme.typography.labelLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Text(
-                        state.preview.ifBlank { "No preview available" },
-                        maxLines = 5,
-                        overflow = TextOverflow.Ellipsis,
-                        style = MaterialTheme.typography.bodyLarge
-                    )
-                }
-            }
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                OutlinedButton(
-                    onClick = onDecline,
-                    modifier = Modifier.weight(1f)
-                ) {
-                    Text("Decline")
-                }
-
-                Button(
-                    onClick = onAccept,
-                    modifier = Modifier.weight(1f)
-                ) {
-                    Text("Accept")
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun ReceivedTextState(
-    text: String,
-    onCopyText: () -> Unit,
-    onClear: () -> Unit
-) {
-    Sync360Surface {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            Text(
-                "Received text",
-                style = MaterialTheme.typography.titleLarge
-            )
-
-            Sync360Surface(containerColor = MaterialTheme.colorScheme.surfaceContainer) {
-                Text(
-                    text,
-                    maxLines = 5,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    style = MaterialTheme.typography.bodyLarge
-                )
-            }
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                OutlinedButton(
-                    onClick = onClear,
-                    modifier = Modifier.weight(1f)
-                ) {
-                    Text("Clear")
-                }
-
-                Button(
-                    onClick = onCopyText,
-                    modifier = Modifier.weight(1f)
-                ) {
-                    Text("Copy text")
                 }
             }
         }

--- a/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/receive/ReceiveScreenViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/receive/ReceiveScreenViewModel.kt
@@ -2,7 +2,7 @@ package com.liftley.sync360.presentation.receive
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.liftley.sync360.data.remote.IncomingServerRequestsController
+import com.liftley.sync360.data.IncomingServerRequestsController
 import com.liftley.sync360.domain.model.ClientServerState
 import com.liftley.sync360.domain.model.UserDecision
 import com.liftley.sync360.domain.repository.ClipboardProvider

--- a/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/receive/components/IdleReceiveStateUi.kt
+++ b/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/receive/components/IdleReceiveStateUi.kt
@@ -1,0 +1,44 @@
+package com.liftley.sync360.presentation.receive.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.liftley.sync360.core.designsystem.icons.Emoji_Nature
+import com.liftley.sync360.presentation.app.components.Sync360Surface
+
+@Composable
+fun IdleReceiveStateUi() {
+    Sync360Surface {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                imageVector = Emoji_Nature,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp)
+            )
+            Text(
+                "Nothing to receive right now",
+                style = MaterialTheme.typography.titleLarge
+            )
+            Text(
+                "Keep Sync360 open on nearby devices",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/receive/components/ReceivedTextStateUi.kt
+++ b/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/receive/components/ReceivedTextStateUi.kt
@@ -1,0 +1,70 @@
+package com.liftley.sync360.presentation.receive.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.liftley.sync360.presentation.app.components.Sync360Surface
+
+@Composable
+fun ReceivedTextStateUi(
+    text: String,
+    onCopyText: () -> Unit,
+    onClear: () -> Unit
+) {
+    Sync360Surface {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                "Received text",
+                style = MaterialTheme.typography.titleLarge
+            )
+
+            Sync360Surface(containerColor = MaterialTheme.colorScheme.surfaceContainer) {
+                Text(
+                    text,
+                    maxLines = 5,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    style = MaterialTheme.typography.bodyLarge
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                OutlinedButton(
+                    onClick = onClear,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text("Clear")
+                }
+
+                Button(
+                    onClick = onCopyText,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text("Copy text")
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/receive/components/TextOfferStateUi.kt
+++ b/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/receive/components/TextOfferStateUi.kt
@@ -1,0 +1,91 @@
+package com.liftley.sync360.presentation.receive.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.liftley.sync360.presentation.app.components.Sync360Surface
+import com.liftley.sync360.presentation.receive.model.ReceiveScreenState
+
+@Composable
+fun TextOfferStateUi(
+    state: ReceiveScreenState.IncomingTextOffer,
+    onAccept: () -> Unit,
+    onDecline: () -> Unit
+) {
+    Sync360Surface {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                "Incoming text",
+                style = MaterialTheme.typography.titleLarge
+            )
+
+            Text(
+                "${state.senderName} wants to send text",
+                style = MaterialTheme.typography.titleMedium
+            )
+
+            Text(
+                "${state.characterCount} characters",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Sync360Surface(containerColor = MaterialTheme.colorScheme.surfaceContainer) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text(
+                        "Preview",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        state.preview.ifBlank { "No preview available" },
+                        maxLines = 5,
+                        overflow = TextOverflow.Ellipsis,
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                OutlinedButton(
+                    onClick = onDecline,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text("Decline")
+                }
+
+                Button(
+                    onClick = onAccept,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text("Accept")
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/send/SendScreen.kt
+++ b/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/send/SendScreen.kt
@@ -2,19 +2,11 @@ package com.liftley.sync360.presentation.send
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonDefaults
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SecondaryTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
@@ -25,18 +17,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.liftley.sync360.core.designsystem.icons.Close
-import com.liftley.sync360.core.designsystem.icons.Emoji_Nature
-import com.liftley.sync360.core.designsystem.icons.Reload
-import com.liftley.sync360.domain.model.DiscoveryStatus
-import com.liftley.sync360.presentation.send.components.NearbyDeviceCard
-import com.liftley.sync360.presentation.send.components.NearbyDeviceEmptyCard
-import com.liftley.sync360.presentation.send.components.TextItemCard
-import com.liftley.sync360.presentation.send.model.SendScreenState
-import com.liftley.sync360.presentation.send.model.SendTab
-import com.liftley.sync360.presentation.send.model.TextSendState
-import com.liftley.sync360.presentation.send.model.NearbyDeviceUiModel
 import com.liftley.sync360.presentation.app.components.Sync360Surface
+import com.liftley.sync360.presentation.send.components.FilesComingSoonContent
+import com.liftley.sync360.presentation.send.components.NearbyDevicesSection
+import com.liftley.sync360.presentation.send.components.TextSendContent
+import com.liftley.sync360.presentation.send.components.TextSendStatusCard
+import com.liftley.sync360.presentation.send.model.SendTab
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 
@@ -103,197 +89,5 @@ fun SendScreen() {
                 }
             }
         )
-    }
-}
-
-@Composable
-private fun TextSendStatusCard(
-    textSendState: TextSendState,
-    onClear: () -> Unit
-) {
-    Sync360Surface {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            if (textSendState != TextSendState.Idle) {
-                IconButton(
-                    onClick = onClear,
-                    colors = IconButtonDefaults.iconButtonColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainer
-                    ),
-                    modifier = Modifier.align(Alignment.End)
-                ) {
-                    Icon(
-                        imageVector = Close,
-                        contentDescription = null
-                    )
-                }
-            }
-
-            when (textSendState) {
-                TextSendState.Idle -> {
-                    Text(
-                        "Your sending nothing right now",
-                        style = MaterialTheme.typography.titleMedium
-                    )
-                }
-
-                is TextSendState.Sending -> {
-                    Text(
-                        "Sending text to ${textSendState.deviceName}",
-                        style = MaterialTheme.typography.titleMedium
-                    )
-                }
-
-                is TextSendState.Sent -> {
-                    Text(
-                        "Text sent to ${textSendState.deviceName}",
-                        style = MaterialTheme.typography.titleMedium
-                    )
-                }
-
-                is TextSendState.Failed -> {
-                    Text(
-                        "Text not sent because ${textSendState.reason}",
-                        style = MaterialTheme.typography.titleMedium
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun TextSendContent(
-    textInput: String,
-    onTextChange: (String) -> Unit,
-    onClearText: () -> Unit
-) {
-    Column(
-        verticalArrangement = Arrangement.spacedBy(16.dp)
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                "Selected Text",
-                style = MaterialTheme.typography.titleLarge
-            )
-            if (textInput.isNotEmpty()) {
-                IconButton(
-                    onClick = onClearText,
-                    colors = IconButtonDefaults.iconButtonColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainer
-                    ),
-                    modifier = Modifier.height(48.dp)
-                ) {
-                    Icon(imageVector = Close, contentDescription = null)
-                }
-            }
-        }
-
-        if (textInput.isBlank()) {
-            Sync360Surface(containerColor = MaterialTheme.colorScheme.surfaceContainer) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(16.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Icon(imageVector = Emoji_Nature, contentDescription = null, modifier = Modifier.size(48.dp))
-                    Text("No text added")
-                }
-            }
-        } else {
-            TextItemCard(textInput)
-        }
-
-        OutlinedTextField(
-            value = textInput,
-            onValueChange = onTextChange,
-            label = { Text("Add text to send") },
-            maxLines = 4,
-            shape = MaterialTheme.shapes.large,
-            modifier = Modifier.fillMaxWidth()
-        )
-    }
-}
-
-@Composable
-private fun FilesComingSoonContent() {
-    Sync360Surface(containerColor = MaterialTheme.colorScheme.surfaceContainer) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Icon(imageVector = Emoji_Nature, contentDescription = null, modifier = Modifier.size(48.dp))
-            Text(
-                "File sending is not ready yet",
-                style = MaterialTheme.typography.titleMedium
-            )
-        }
-    }
-}
-
-@Composable
-private fun NearbyDevicesSection(
-    screenState: SendScreenState,
-    onReloadClick: () -> Unit,
-    onDeviceClick: (NearbyDeviceUiModel) -> Unit
-) {
-    Sync360Surface {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    "Nearby Devices",
-                    style = MaterialTheme.typography.titleLarge
-                )
-
-                IconButton(
-                    colors = IconButtonDefaults.iconButtonColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainer
-                    ),
-                    modifier = Modifier.height(48.dp),
-                    enabled = screenState.discoveryStatus == DiscoveryStatus.Idle,
-                    onClick = onReloadClick
-                ) {
-                    Icon(
-                        imageVector = Reload,
-                        contentDescription = null
-                    )
-                }
-            }
-
-            screenState.nearbyDevices.forEach { device ->
-                NearbyDeviceCard(
-                    device = device,
-                    onClick = { onDeviceClick(device) }
-                )
-            }
-
-            NearbyDeviceEmptyCard(
-                status = screenState.discoveryStatus,
-                onReloadClick = onReloadClick
-            )
-        }
     }
 }

--- a/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/send/SendScreenViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/send/SendScreenViewModel.kt
@@ -3,7 +3,7 @@ package com.liftley.sync360.presentation.send
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.liftley.sync360.data.NetworkServicesController
-import com.liftley.sync360.data.remote.OutgoingRequestsController
+import com.liftley.sync360.data.OutgoingRequestsController
 import com.liftley.sync360.domain.model.NearbyDevice
 import com.liftley.sync360.presentation.send.model.toNearbyDeviceUiModel
 import com.liftley.sync360.presentation.send.model.SendScreenState

--- a/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/send/components/FilesComingSoonContent.kt
+++ b/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/send/components/FilesComingSoonContent.kt
@@ -1,0 +1,35 @@
+package com.liftley.sync360.presentation.send.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.liftley.sync360.core.designsystem.icons.Emoji_Nature
+import com.liftley.sync360.presentation.app.components.Sync360Surface
+
+@Composable
+fun FilesComingSoonContent() {
+    Sync360Surface(containerColor = MaterialTheme.colorScheme.surfaceContainer) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(imageVector = Emoji_Nature, contentDescription = null, modifier = Modifier.size(48.dp))
+            Text(
+                "File sending is not ready yet",
+                style = MaterialTheme.typography.titleMedium
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/send/components/NearbyDeviceEmptyCard.kt
+++ b/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/send/components/NearbyDeviceEmptyCard.kt
@@ -1,11 +1,5 @@
 package com.liftley.sync360.presentation.send.components
 
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -13,46 +7,25 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularWavyProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.liftley.sync360.domain.model.DiscoveryStatus
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Preview
 @Composable
 fun NearbyDeviceEmptyCard(
-    status: DiscoveryStatus = DiscoveryStatus.Idle,
+    status: DiscoveryStatus = DiscoveryStatus.Running,
     onReloadClick: () -> Unit = {}
 ) {
-    val infiniteTransition = rememberInfiniteTransition("Loading Animation")
-
-    val progress by infiniteTransition.animateFloat(
-        initialValue = 0f,
-        targetValue = 2f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(2500),
-            repeatMode = RepeatMode.Restart
-        ),
-        label = "Loading Progress"
-    )
-
-    val startAngle = progress * 360f
-
-    val sweepAngle = (progress - 1f) * 360f
-
-
     val title = when (status) {
         DiscoveryStatus.Idle -> "No Device Found"
         DiscoveryStatus.Starting -> "Starting Discovery"
@@ -83,18 +56,8 @@ fun NearbyDeviceEmptyCard(
             verticalArrangement = Arrangement.spacedBy(4.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            if (status == DiscoveryStatus.Running) {
-                Canvas(modifier = Modifier.size(48.dp)) {
-                    drawArc(
-                        topLeft = center + Offset(x = -24f, y = -24f),
-                        color = Color(0xFF4C662B),
-                        startAngle = startAngle,
-                        useCenter = false,
-                        sweepAngle = sweepAngle,
-                        size = Size(48f, 48f),
-                        style = Stroke(10f, cap = StrokeCap.Round)
-                    )
-                }
+            if (status != DiscoveryStatus.Idle) {
+                CircularWavyProgressIndicator()
             }
             Text(
                 title,

--- a/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/send/components/NearbyDevicesSection.kt
+++ b/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/send/components/NearbyDevicesSection.kt
@@ -1,0 +1,75 @@
+package com.liftley.sync360.presentation.send.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.liftley.sync360.core.designsystem.icons.Reload
+import com.liftley.sync360.domain.model.DiscoveryStatus
+import com.liftley.sync360.presentation.app.components.Sync360Surface
+import com.liftley.sync360.presentation.send.model.NearbyDeviceUiModel
+import com.liftley.sync360.presentation.send.model.SendScreenState
+
+@Composable
+fun NearbyDevicesSection(
+    screenState: SendScreenState,
+    onReloadClick: () -> Unit,
+    onDeviceClick: (NearbyDeviceUiModel) -> Unit
+) {
+    Sync360Surface {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    "Nearby Devices",
+                    style = MaterialTheme.typography.titleLarge
+                )
+
+                IconButton(
+                    colors = IconButtonDefaults.iconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainer
+                    ),
+                    modifier = Modifier.height(48.dp),
+                    enabled = screenState.discoveryStatus == DiscoveryStatus.Idle,
+                    onClick = onReloadClick
+                ) {
+                    Icon(
+                        imageVector = Reload,
+                        contentDescription = null
+                    )
+                }
+            }
+
+            screenState.nearbyDevices.forEach { device ->
+                NearbyDeviceCard(
+                    device = device,
+                    onClick = { onDeviceClick(device) }
+                )
+            }
+
+            NearbyDeviceEmptyCard(
+                status = screenState.discoveryStatus,
+                onReloadClick = onReloadClick
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/send/components/TextItemCard.kt
+++ b/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/send/components/TextItemCard.kt
@@ -21,7 +21,7 @@ fun TextItemCard(item: String) {
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Text(item, style = MaterialTheme.typography.titleMedium, maxLines = 5, overflow = TextOverflow.Ellipsis)
+            Text(item, style = MaterialTheme.typography.titleMedium, maxLines = 4, overflow = TextOverflow.Ellipsis)
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/send/components/TextSendContent.kt
+++ b/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/send/components/TextSendContent.kt
@@ -1,0 +1,81 @@
+package com.liftley.sync360.presentation.send.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.liftley.sync360.core.designsystem.icons.Close
+import com.liftley.sync360.core.designsystem.icons.Emoji_Nature
+import com.liftley.sync360.presentation.app.components.Sync360Surface
+
+@Composable
+fun TextSendContent(
+    textInput: String,
+    onTextChange: (String) -> Unit,
+    onClearText: () -> Unit
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                "Selected Text",
+                style = MaterialTheme.typography.titleLarge
+            )
+            if (textInput.isNotEmpty()) {
+                IconButton(
+                    onClick = onClearText,
+                    colors = IconButtonDefaults.iconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainer
+                    ),
+                    modifier = Modifier.height(48.dp)
+                ) {
+                    Icon(imageVector = Close, contentDescription = null)
+                }
+            }
+        }
+
+        if (textInput.isBlank()) {
+            Sync360Surface(containerColor = MaterialTheme.colorScheme.surfaceContainer) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Icon(imageVector = Emoji_Nature, contentDescription = null, modifier = Modifier.size(48.dp))
+                    Text("No text added")
+                }
+            }
+        } else {
+            TextItemCard(textInput)
+        }
+
+        OutlinedTextField(
+            value = textInput,
+            onValueChange = onTextChange,
+            label = { Text("Add text to send") },
+            maxLines = 4,
+            shape = MaterialTheme.shapes.large,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/send/components/TextSendStatusCard.kt
+++ b/shared/src/commonMain/kotlin/com/liftley/sync360/presentation/send/components/TextSendStatusCard.kt
@@ -1,0 +1,79 @@
+package com.liftley.sync360.presentation.send.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.liftley.sync360.core.designsystem.icons.Close
+import com.liftley.sync360.presentation.app.components.Sync360Surface
+import com.liftley.sync360.presentation.send.model.TextSendState
+
+@Composable
+fun TextSendStatusCard(
+    textSendState: TextSendState,
+    onClear: () -> Unit
+) {
+    Sync360Surface {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            if (textSendState != TextSendState.Idle) {
+                IconButton(
+                    onClick = onClear,
+                    colors = IconButtonDefaults.iconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainer
+                    ),
+                    modifier = Modifier.align(Alignment.End)
+                ) {
+                    Icon(
+                        imageVector = Close,
+                        contentDescription = null
+                    )
+                }
+            }
+
+            when (textSendState) {
+                TextSendState.Idle -> {
+                    Text(
+                        "Your sending nothing right now",
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                }
+
+                is TextSendState.Sending -> {
+                    Text(
+                        "Sending text to ${textSendState.deviceName}",
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                }
+
+                is TextSendState.Sent -> {
+                    Text(
+                        "Text sent to ${textSendState.deviceName}",
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                }
+
+                is TextSendState.Failed -> {
+                    Text(
+                        "Text not sent because ${textSendState.reason}",
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR updates Sync360 to reflect the current Android text-transfer milestone and cleans up the Send/Receive UI structure.

The README previously described the older ping/request-response prototype. It now describes the real working flow: Android devices discover each other locally, sender creates a text offer, receiver accepts or declines, accepted text is transferred, and the receiver can copy the received text.

## What changed

- Updated README hero copy and current milestone text.
- Replaced the README demo GIF with the latest Android text-transfer demo.
- Updated `screenshots/README.md` to describe the new hero demo.
- Replaced stale ping prototype wording with the current text offer/transfer flow.
- Added honest status notes for what is not implemented yet:
  - file picker
  - file transfer
  - transfer progress
  - Android save-to-downloads/storage
  - security/session validation
  - desktop networking flow
  - iOS implementation
- Split large Send screen UI blocks into smaller composables.
- Split Receive screen UI states into smaller composables.
- Moved Ktor client timeout configuration to the `HttpClient` setup.
- Added timeout handling for request timeout exceptions.
- Made text offer response handling in the server more explicit.
- Added a guard so receivers decline new text offers when already busy or still holding received content.

## Why

The project has moved beyond the old ping milestone. The public README needed to match the real current behavior without claiming unfinished file-transfer features.

The UI split also makes the Send and Receive screens easier to read and continue building manually.

## Notes

Sync360 is still Android-first and early-stage.

Text transfer works. File transfer, storage handling, progress, security, desktop support, and iOS support are still future work.

## Testing

-Its building and the app also works on android properly